### PR TITLE
Fix OAuth authentication failing

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,10 +1,10 @@
 module net.hycrafthd.minecraft_authenticator {
-
-    exports net.hycrafthd.minecraft_authenticator;
-    exports net.hycrafthd.minecraft_authenticator.login;
-    exports net.hycrafthd.minecraft_authenticator.util.function;
-
-    requires transitive com.google.gson;
-
-    opens net.hycrafthd.minecraft_authenticator.microsoft.api to com.google.gson;
+	
+	exports net.hycrafthd.minecraft_authenticator;
+	exports net.hycrafthd.minecraft_authenticator.login;
+	exports net.hycrafthd.minecraft_authenticator.util.function;
+	
+	requires transitive com.google.gson;
+	
+	opens net.hycrafthd.minecraft_authenticator.microsoft.api to com.google.gson;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,8 +1,10 @@
 module net.hycrafthd.minecraft_authenticator {
-	
-	exports net.hycrafthd.minecraft_authenticator;
-	exports net.hycrafthd.minecraft_authenticator.login;
-	exports net.hycrafthd.minecraft_authenticator.util.function;
-	
-	requires transitive com.google.gson;
+
+    exports net.hycrafthd.minecraft_authenticator;
+    exports net.hycrafthd.minecraft_authenticator.login;
+    exports net.hycrafthd.minecraft_authenticator.util.function;
+
+    requires transitive com.google.gson;
+
+    opens net.hycrafthd.minecraft_authenticator.microsoft.api to com.google.gson;
 }


### PR DESCRIPTION
This is essentially a really simple fix, and only opens `net.hycrafthd.minecraft_authenticator.microsoft.api` to
`com.google.gson`. 
Tested to work through locally building with this change, adding the local JAR file to the project, and initiating an authentication session.

Beware of my IntelliJ induced formatting changes 😅

Relevant Stacktrace:
```
net.hycrafthd.minecraft_authenticator.microsoft.MicrosoftAuthenticationException: Cannot get oAuth token
	at net.hycrafthd.minecraft_authenticator.microsoft.MicrosoftAuthentication.createAuthenticationFile(MicrosoftAuthentication.java:30) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.login.Authenticator.lambda$ofMicrosoft$1(Authenticator.java:133) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.login.Authenticator.run(Authenticator.java:368) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.login.Authenticator.run(Authenticator.java:340) ~[minecraft_authenticator-3.0.5.jar:?]
	at eu.girc.launcher.util.AuthUtil.microsoftLogin(AuthUtil.java:33) ~[Launcher-1.1.0.jar:?]
	at eu.girc.launcher.javafx.MicrosoftLoginScene.loginCheck(MicrosoftLoginScene.java:67) ~[Launcher-1.1.0.jar:?]
	at com.sun.javafx.collections.ListListenerHelper$SingleChange.fireValueChangedEvent(ListListenerHelper.java:164) ~[javafx-base-17.0.6-win.jar:?]
	at com.sun.javafx.collections.ListListenerHelper.fireValueChangedEvent(ListListenerHelper.java:73) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ObservableListBase.fireChange(ObservableListBase.java:239) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.FXCollections$UnmodifiableObservableListImpl.lambda$new$0(FXCollections.java:963) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.WeakListChangeListener.onChanged(WeakListChangeListener.java:88) ~[javafx-base-17.0.6-win.jar:?]
	at com.sun.javafx.collections.ListListenerHelper$SingleChange.fireValueChangedEvent(ListListenerHelper.java:164) ~[javafx-base-17.0.6-win.jar:?]
	at com.sun.javafx.collections.ListListenerHelper.fireValueChangedEvent(ListListenerHelper.java:73) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ObservableListBase.fireChange(ObservableListBase.java:239) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ListChangeBuilder.commit(ListChangeBuilder.java:482) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ListChangeBuilder.endChange(ListChangeBuilder.java:541) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ObservableListBase.endChange(ObservableListBase.java:211) ~[javafx-base-17.0.6-win.jar:?]
	at javafx.collections.ModifiableObservableListBase.add(ModifiableObservableListBase.java:162) ~[javafx-base-17.0.6-win.jar:?]
	at java.util.AbstractList.add(AbstractList.java:111) ~[?:?]
	at javafx.scene.web.WebHistory.lambda$new$0(WebHistory.java:169) ~[javafx-web-17.0.6-win.jar:?]
	at com.sun.webkit.BackForwardList.notifyChanged(BackForwardList.java:311) ~[javafx-web-17.0.6-win.jar:?]
	at com.sun.webkit.network.URLLoaderBase.twkDidFinishLoading(Native Method) ~[javafx-web-17.0.6-win.jar:?]
	at com.sun.webkit.network.HTTP2Loader.notifyDidFinishLoading(HTTP2Loader.java:578) ~[javafx-web-17.0.6-win.jar:?]
	at com.sun.webkit.network.HTTP2Loader.lambda$callBackIfNotCanceled$10(HTTP2Loader.java:441) ~[javafx-web-17.0.6-win.jar:?]
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457) ~[javafx-graphics-17.0.6-win.jar:?]
	at java.security.AccessController.doPrivileged(AccessController.java:399) ~[?:?]
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456) ~[javafx-graphics-17.0.6-win.jar:?]
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96) ~[javafx-graphics-17.0.6-win.jar:?]
	at com.sun.glass.ui.win.WinApplication._runLoop(Native Method) ~[javafx-graphics-17.0.6-win.jar:?]
	at com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184) ~[javafx-graphics-17.0.6-win.jar:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: com.google.gson.JsonIOException: Failed making field 'net.hycrafthd.minecraft_authenticator.microsoft.api.OAuthTokenResponse#tokenType' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
	at com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:38) ~[gson-2.10.1.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:286) ~[gson-2.10.1.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.getAdapter(Gson.java:556) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1226) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1329) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1271) ~[gson-2.10.1.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthServiceRequest(MicrosoftService.java:122) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:81) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:67) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:63) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.MicrosoftAuthentication.createAuthenticationFile(MicrosoftAuthentication.java:26) ~[minecraft_authenticator-3.0.5.jar:?]
	... 30 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.String net.hycrafthd.minecraft_authenticator.microsoft.api.OAuthTokenResponse.tokenType accessible: module net.hycrafthd.minecraft_authenticator does not "opens net.hycrafthd.minecraft_authenticator.microsoft.api" to module com.google.gson
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) ~[?:?]
	at java.lang.reflect.Field.checkCanSetAccessible(Field.java:178) ~[?:?]
	at java.lang.reflect.Field.setAccessible(Field.java:172) ~[?:?]
	at com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:35) ~[gson-2.10.1.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:286) ~[gson-2.10.1.jar:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.getAdapter(Gson.java:556) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1226) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1329) ~[gson-2.10.1.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:1271) ~[gson-2.10.1.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthServiceRequest(MicrosoftService.java:122) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:81) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:67) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.service.MicrosoftService.oAuthTokenFromCode(MicrosoftService.java:63) ~[minecraft_authenticator-3.0.5.jar:?]
	at net.hycrafthd.minecraft_authenticator.microsoft.MicrosoftAuthentication.createAuthenticationFile(MicrosoftAuthentication.java:26) ~[minecraft_authenticator-3.0.5.jar:?]
	... 30 more
```